### PR TITLE
Agents generate less garbage while working

### DIFF
--- a/src/jvm/clojure/lang/Agent.java
+++ b/src/jvm/clojure/lang/Agent.java
@@ -136,8 +136,12 @@ static class Action implements Runnable{
 				popped = action.agent.aq.compareAndSet(prior, next);
 				}
 
-			if(error == null && next.q.count() > 0)
-				((Action) next.q.peek()).execute();
+			if(error == null) {
+				Action nextAction = (Action) next.q.peek();
+		                if (null != nextAction) {
+					nextAction.execute();
+				}
+		            }
 			}
 		finally
 			{


### PR DESCRIPTION
This patch removes the call to 'count' during an agent's processing, which is just an 'is-empty' test, which can also be achieved by a null test on the peek.

Overall, 'count' seems to generate a lot of garbage, the holistic reduction of which would be out-of-scope for a simple patch on a maintenance branch.
