### PR TITLE
Avoid evaluation when adding metadata to a LazySeq

### DIFF
--- a/src/jvm/clojure/lang/LazySeq.java
+++ b/src/jvm/clojure/lang/LazySeq.java
@@ -30,8 +30,16 @@ private LazySeq(IPersistentMap meta, ISeq s){
 	this.s = s;
 }
 
+private LazySeq(IPersistentMap meta, IFn fn){
+	super(meta);
+	this.fn = fn;
+}
+
 public Obj withMeta(IPersistentMap meta){
-	return new LazySeq(meta, seq());
+	if(fn != null)
+		return new LazySeq(meta, this.fn);
+	else
+		return new LazySeq(meta, seq());
 }
 
 final synchronized Object sval(){

--- a/test/clojure/test_clojure/sequences.clj
+++ b/test/clojure/test_clojure/sequences.clj
@@ -115,6 +115,14 @@
       (lazy-seq (into-array [1 2])) '(1 2) ))
 
 
+(deftest test-laziness
+  (let [x (atom nil)
+        s (lazy-seq (do (swap! x (fn [_] true))
+                      []))
+        s* (with-meta s {:a 1})]
+    (is (= nil @x))))
+
+
 (deftest test-seq
   (is (not (seq? (seq []))))
   (is (seq? (seq [1 2])))


### PR DESCRIPTION
I've made a minor modification to clojure.lang.LazySeq which prevents evaluation of the embedded function when adding meta-data to the sequence.  I've also added a small test which confirms the behaviour.
