### PR TITLE
The docstring in rational? should come before the argument list

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -3183,10 +3183,11 @@
   (or (instance? Double n)
       (instance? Float n)))
 
-(defn rational? [n]
+(defn rational?
   "Returns true if n is a rational number"
   {:added "1.0"
    :static true}
+  [n]
   (or (integer? n) (ratio? n) (decimal? n)))
 
 (defn bigint


### PR DESCRIPTION
There is a bug in the function definition of rational?

Right now, (doc rational?) results in:

---

clojure.core/rational?
([n])
  nil
nil

it should result in:

---

clojure.core/rational?
([n])
  Returns true if n is a rational number
nil
