### PR TITLE
Adds support for FreeDesktop's xdg-open in clojure.java.browse/browse-url.

### DIFF
--- a/src/clj/clojure/java/browse.clj
+++ b/src/clj/clojure/java/browse.clj
@@ -17,7 +17,13 @@
   (-> "os.name" System/getProperty .toLowerCase
     (.startsWith "mac os x")))
 
-(def ^:dynamic *open-url-script* (when (macosx?) "/usr/bin/open"))
+(defn- freedesktop? []
+  (not (.startsWith "which" (:out (sh/sh "which" "xdg-open")))))
+
+(def ^:dynamic *open-url-script*
+  (cond
+    (macosx?) "/usr/bin/open"
+    (freedesktop?) "xdg-open"))
 
 (defn- open-url-in-browser
   "Opens url (a string) in the default system web browser.  May not


### PR DESCRIPTION
This allows environments that support FreeDesktop to browse a URL in their default browser. This is important because unless the desktop environment bridges to Java (like Gnome does) the URL will be opened in a Swing window, which is not always desired.

See: http://dev.clojure.org/jira/browse/CLJ-920
