### PR TITLE
Fixed clojure.string/replace doc

### DIFF
--- a/src/clj/clojure/string.clj
+++ b/src/clj/clojure/string.clj
@@ -67,7 +67,7 @@ Design notes for clojure.string:
 
    string / string
    char / char
-   pattern / (string or function of match).
+   pattern / (string or function of match groups).
 
    See also replace-first."
   {:added "1.2"}
@@ -107,7 +107,7 @@ Design notes for clojure.string:
 
    char / char
    string / string
-   pattern / (string or function of match).
+   pattern / (string or function of match groups).
 
    See also replace-all."
   {:added "1.2"}


### PR DESCRIPTION
A little mistake in clojure.string/replace docstring, if replace is a function, it will be called with match groups vector, not the match object itself.
