### PR TITLE
Fixed typo in filterv-example

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -132,7 +132,7 @@ must be free of side-effects.
     (= [] (filterv even? [1 3 5]))
     ;=> true
 
-    (= [2 4] (filter even? [1 2 3 4 5]))
+    (= [2 4] (filterv even? [1 2 3 4 5]))
     ;=> true
 
 ### 2.4 clojure.core/ex-info and clojure.core/ex-data


### PR DESCRIPTION
I assume this is a typo
