### PR TITLE
fixed rename-keys to not delete entries when there is a collision

### DIFF
--- a/src/clj/clojure/set.clj
+++ b/src/clj/clojure/set.clj
@@ -80,11 +80,10 @@
   [map kmap]
     (reduce 
      (fn [m [old new]]
-       (if (and (not= old new)
-                (contains? m old))
-         (-> m (assoc new (get m old)) (dissoc old))
+       (if (contains? map old)
+         (assoc m new (get map old))
          m)) 
-     map kmap))
+     (apply dissoc map (keys kmap)) kmap))
 
 (defn rename
   "Returns a rel of the maps in xrel with the keys in kmap renamed to the vals in kmap"

--- a/test/clojure/test_clojure/clojure_set.clj
+++ b/test/clojure/test_clojure/clojure_set.clj
@@ -162,8 +162,9 @@
 
 (deftest test-rename-keys
   (are [x y] (= x y)
-    (set/rename-keys {:a "one" :b "two"} {:a :z}) {:z "one" :b "two"}
-    ))
+       (set/rename-keys {:a "one" :b "two"} {:a :z}) {:z "one" :b "two"}
+       (set/rename-keys {:a "one" :b "two"} {:a :z :c :y}) {:z "one" :b "two"}
+       (set/rename-keys {:a "one" :b "two" :c "three"} {:a :b :b :a}) {:a "two" :b "one" :c "three"}))
 
 (deftest test-index
   (are [x y] (= x y)


### PR DESCRIPTION
Small fix to prevent key collisions deleting keys from the result map
