### PR TITLE
Add "where" macro.

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -1549,6 +1549,15 @@
               (list form x)))
   ([x form & more] `(->> (->> ~x ~form) ~@more)))
 
+(defmacro where
+  "Synonym of let. Use with ->> to provide binding after expressions (Haskell binding style)
+  Example:
+  (->> (+ x y) (where [x 3 y 2]))
+  which would expand to:
+  (let* [x 3 y 2] (+ x y))"
+  {:added "1.5"}
+  [& body] `(let ~@body))
+
 (def map)
 
 (defn ^:private check-valid-options


### PR DESCRIPTION
Synonym of let. Use with ->> to provide binding after expressions (Haskell binding style)
