### PR TITLE
Give PersistentVector as fn the same behavior as PersistentMap

### DIFF
--- a/src/jvm/clojure/lang/APersistentVector.java
+++ b/src/jvm/clojure/lang/APersistentVector.java
@@ -261,6 +261,10 @@ public Object invoke(Object arg1) {
 	throw new IllegalArgumentException("Key must be integer");
 }
 
+public Object invoke(Object arg1, Object notFound) {
+	return valAt(arg1, notFound);
+}
+
 public Iterator iterator(){
 	//todo - something more efficient
 	return new Iterator(){


### PR DESCRIPTION
This trivial patch implements the 2-arity case for APersistentVector.

Use case:

``` clojure
user=> ({1 2} 3 :notFound)
:notFound

user=> ([1 2] 3 :notFound)
;ArityException Wrong number of args (2) passed to: PersistentVector  clojure.lang.AFn.throwArity (AFn.java:437)
```
