### PR TITLE
Ensure references in the clojure.core/ns form are valid.

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5144,6 +5144,11 @@
         references (remove #(= :gen-class (first %)) references)
         ;ns-effect (clojure.core/in-ns name)
         ]
+    (doseq [ref (map first references)]
+      (when-not (and (or (symbol? ref)
+                         (keyword? ref))
+                     (contains? (set ["require" "use" "import" "refer-clojure"]) (clojure.core/name ref)))
+        (throw (IllegalArgumentException. (str ref " is not a valid reference.")))))
     `(do
        (clojure.core/in-ns '~name)
        (with-loading-context


### PR DESCRIPTION
Right now, any reference is looked up in clojure.core namespace and invoked.  That means:

(ns foo (:print "I AM A ROBOT")) will print "I AM A ROBOT" when evaluated.
