### PR TITLE
Allow negative substring indices for (subs)

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -4418,13 +4418,27 @@
    :static true}
   [v] (instance? clojure.lang.Var v))
 
+(defn rindex
+  "Returns the index of s relative to the start when i is positive, or
+  relative to the end when i is negative."
+  {:added "1.5"
+   :static true}
+  [^String s i] (+ i (if (< i 0) (count s) 0)))
+
+
 (defn subs
   "Returns the substring of s beginning at start inclusive, and ending
-  at end (defaults to length of string), exclusive."
+  at end (defaults to length of string), exclusive. The start and end
+  indices are relative from the start of the string when positive, and
+  relative to the end when negative. "
   {:added "1.0"
    :static true}
-  (^String [^String s start] (. s (substring start)))
-  (^String [^String s start end] (. s (substring start end))))
+  (^String [^String s start] (. s (substring (rindex s start))))
+  (^String [^String s start end]
+             (. s (substring (rindex s start) (rindex s end))))
+  #_(^String [^String s start] (. s (substring start)))
+  #_(^String [^String s start end]
+             (. s (substring start end))))
 
 (defn max-key
   "Returns the x for which (k x), a number, is greatest."

--- a/src/script/run_tests.clj
+++ b/src/script/run_tests.clj
@@ -48,6 +48,7 @@ clojure.test-clojure.sequences
 clojure.test-clojure.serialization
 clojure.test-clojure.special
 clojure.test-clojure.string
+clojure.test-clojure.subs
 clojure.test-clojure.test
 clojure.test-clojure.test-fixtures
 clojure.test-clojure.transients

--- a/test/clojure/test_clojure/subs.clj
+++ b/test/clojure/test_clojure/subs.clj
@@ -1,0 +1,24 @@
+;   Copyright (c) Ian Eure. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+(ns clojure.test-clojure.subs
+  (:use clojure.test))
+
+(deftest test-subs
+  (let [s "One morning, as Gregor Samsa was waking up from anxious dreams"]
+    (testing "Returns substring relative to the start with positive args"
+      (testing "With start"
+        (is (= "waking up from anxious dreams" (subs s 33))))
+      (testing "With start and end"
+        (is (= "Gregor Samsa" (subs s 16 28)))))
+
+    (testing "Returns substring relative to the end with negative args"
+      (testing "With start"
+        (is (= "anxious dreams" (subs s -14))))
+      (testing "With start and end"
+        (is (= "from anxious" (subs s 43 -7)))))))


### PR DESCRIPTION
This adds Python-style negative string indices for `(subs)`, e.g.:

```
(subs "foo bar" -3) ;; -> "bar"
```
