### PR TITLE
Add "flip" and "partial*" functions

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2385,6 +2385,19 @@
   ([f arg1 arg2 arg3 & more]
    (fn [& args] (apply f arg1 arg2 arg3 (concat more args)))))
 
+(defn flip
+  "Flips the given function arguments."
+  {:added "1.4"}
+  [f]
+  (comp (partial apply f) reverse list))
+
+(defn partial*
+  "Flips the given function arguments and returns a new function
+  partially applied to a variable number of arguments."
+  {:added "1.4"}
+  [f & args]
+  (apply partial (flip f) args))
+
 ;;;;;;;;;;;;;;;;;;; sequence fns  ;;;;;;;;;;;;;;;;;;;;;;;
 (defn sequence
   "Coerces coll to a (possibly empty) sequence, if it is not already


### PR DESCRIPTION
Useful for more point-free programming in Clojure.
