### PR TITLE
Make TransientArrayMap's assoc! function behavior be the same with PersistentArrayMap assoc

### DIFF
--- a/src/jvm/clojure/lang/PersistentArrayMap.java
+++ b/src/jvm/clojure/lang/PersistentArrayMap.java
@@ -384,7 +384,7 @@ static final class TransientArrayMap extends ATransientMap {
 			}
 		else //didn't have key, grow
 			{
-			if(len >= array.length)
+			if(len > array.length)
 				return PersistentHashMap.create(array).asTransient().assoc(key, val);
 			array[len++] = key;
 			array[len++] = val;


### PR DESCRIPTION
In PersistentArrayMap's assoc method, it cast  itself to hash-map when the array length **is greater than** HASHTABLE_THRESHOLD(the value is 16):

```
if(array.length > HASHTABLE_THRESHOLD)     //PersistentArrayMap.java 200
    return createHT(array).assoc(key, val);
```

But in TransientArrayMap's doAssoc method,it cast itself to TransientHashMap when the array length **is greater than or equals** to the array's capacity:

```
if(len >= array.length)   //PersistentArrayMap.java   387
    return PersistentHashMap.create(array).asTransient().assoc(key, val);
```

And the capacity is the maxim value of HASHTABLE_THRESHOLD and initial objects count:

```
public TransientArrayMap(Object[] array){
    this.owner = Thread.currentThread();
    this.array = new Object[Math.max(HASHTABLE_THRESHOLD, array.length)];
```

So the assoc/assoc! function behavior between TransientArrayMap and PersistentArrayMap is different, the time to cast itself to hash-map is different , sometimes make me confused, i think they could be the same.Thanks.
