### PR TITLE
Fix docstring typo in main.clj ("from from")

### DIFF
--- a/src/clj/clojure/main.clj
+++ b/src/clj/clojure/main.clj
@@ -413,7 +413,7 @@ java -cp clojure.jar clojure.main -i init.clj script.clj args...")
   main options:
     -m, --main ns-name  Call the -main function from a namespace with args
     -r, --repl          Run a repl
-    path                Run a script from from a file or resource
+    path                Run a script from a file or resource
     -                   Run a script from standard input
     -h, -?, --help      Print this help message and exit
 


### PR DESCRIPTION
I know this cannot be merged since I haven't signed the CA (yet) so I hope somebody who has can do the same fix. The --help produced by main is the public face of clojure so it makes a better impression without typos :)
