### PR TITLE
Make mapcat not indicate that it can accept a variable number of colls

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2519,7 +2519,7 @@
   to f and colls.  Thus function f should return a collection."
   {:added "1.0"
    :static true}
-  [f & colls]
+  [f colls]
     (apply concat (apply map f colls)))
 
 (defn filter


### PR DESCRIPTION
The signature indicates that (mapcat #(list (inc %)) [1 2 3] [4 5 6]) should be okay. However, it throws a ArityException since under the hood it's doing (apply map #(list (inc %)) '([1 2 3] '[4 5 6])).
