### PR TITLE
source of a function can fail for local files

### DIFF
--- a/src/clj/clojure/repl.clj
+++ b/src/clj/clojure/repl.clj
@@ -142,7 +142,8 @@ itself (not its value) is returned. The reader macro #'x expands to (var x)."}})
   [x]
   (when-let [v (resolve x)]
     (when-let [filepath (:file (meta v))]
-      (when-let [strm (.getResourceAsStream (RT/baseLoader) filepath)]
+      (when-let [strm (or (.getResourceAsStream (RT/baseLoader) filepath)
+                          (java.io.FileInputStream. filepath))]
         (with-open [rdr (LineNumberReader. (InputStreamReader. strm))]
           (dotimes [_ (dec (:line (meta v)))] (.readLine rdr))
           (let [text (StringBuilder.)


### PR DESCRIPTION
Requesting the source of a function evaluated as part of a REPL session will fail to
find the source even if the location is known.  Current code assumes the source is in a
JAR and fails if the path is to a local file.

Small mod enables the source to be found under these circumstances.
