### PR TITLE
Update core.clj

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2290,34 +2290,34 @@
   "Must be called in a transaction. Sets the in-transaction-value of
   ref to:
 
-  (apply fun in-transaction-value-of-ref args)
+  (apply f in-transaction-value-of-ref args)
 
   and returns the in-transaction-value of ref.
 
   At the commit point of the transaction, sets the value of ref to be:
 
-  (apply fun most-recently-committed-value-of-ref args)
+  (apply f most-recently-committed-value-of-ref args)
 
-  Thus fun should be commutative, or, failing that, you must accept
+  Thus f should be commutative, or, failing that, you must accept
   last-one-in-wins behavior.  commute allows for more concurrency than
   ref-set."
   {:added "1.0"
    :static true}
 
-  [^clojure.lang.Ref ref fun & args]
-    (. ref (commute fun args)))
+  [^clojure.lang.Ref ref f & args]
+    (. ref (commute f args)))
 
 (defn alter
   "Must be called in a transaction. Sets the in-transaction-value of
   ref to:
 
-  (apply fun in-transaction-value-of-ref args)
+  (apply f in-transaction-value-of-ref args)
 
   and returns the in-transaction-value of ref."
   {:added "1.0"
    :static true}
-  [^clojure.lang.Ref ref fun & args]
-    (. ref (alter fun args)))
+  [^clojure.lang.Ref ref f & args]
+    (. ref (alter f args)))
 
 (defn ref-set
   "Must be called in a transaction. Sets the value of ref.

--- a/test/clojure/test_clojure/pprint/test_cl_format.clj
+++ b/test/clojure/test_clojure/pprint/test_cl_format.clj
@@ -697,12 +697,12 @@
 ;  (foo-g 3.14L1200) "*********|?????????|%%%%%%%%%|3.14L+1200"
 )
 
-(defn type-clash-error [fun nargs argnum right-type wrong-type]
+(defn type-clash-error [f nargs argnum right-type wrong-type]
   (format nil ;; CLtL has this format string slightly wrong
           "~&Function ~S requires its ~:[~:R ~;~*~]~
            argument to be of type ~S,~%but it was called ~
            with an argument of type ~S.~%" 
-          fun (= nargs 1) argnum right-type wrong-type)) 
+          f (= nargs 1) argnum right-type wrong-type)) 
 
 (simple-tests cltl-Newline-tests
   (type-clash-error 'aref nil 2 'integer 'vector)


### PR DESCRIPTION
replace 'fun' with 'f' in core/alter and core/commute doc strings to keep consistent across clojure/core docs. (sorry for taking out the 'fun' :) ) 