### PR TITLE
Fixed typo in docstring of defonce

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5573,7 +5573,7 @@
   `(clojure.core/refer '~'clojure.core ~@filters))
 
 (defmacro defonce
-  "defs name to have the root value of the expr iff the named var has no root value,
+  "defs name to have the root value of the expr if the named var has no root value,
   else expr is unevaluated"
   {:added "1.0"}
   [name expr]


### PR DESCRIPTION
There was a typo in the docstring of defonce.