### PR TITLE
clojure.java.* white-space cleanup

### DIFF
--- a/src/clj/clojure/java/browse.clj
+++ b/src/clj/clojure/java/browse.clj
@@ -44,15 +44,15 @@
   work on all platforms.  Returns url on success, nil if not
   supported."
   [url]
-  (try 
-    (when (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop" 
+  (try
+    (when (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop"
       "isDesktopSupported" (to-array nil))
-      (-> (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop" 
+      (-> (clojure.lang.Reflector/invokeStaticMethod "java.awt.Desktop"
             "getDesktop" (to-array nil))
         (.browse (URI. url)))
       url)
     (catch ClassNotFoundException e
-      nil)))        
+      nil)))
 
 (defn- open-url-in-swing
  "Opens url (a string) in a Swing window."

--- a/src/clj/clojure/java/browse_ui.clj
+++ b/src/clj/clojure/java/browse_ui.clj
@@ -27,4 +27,3 @@
       (.setContentPane (javax.swing.JScrollPane. htmlpane))
       (.setBounds 32 32 700 900)
       (.show))))
-      

--- a/src/clj/clojure/java/io.clj
+++ b/src/clj/clojure/java/io.clj
@@ -6,12 +6,12 @@
 ;   the terms of this license.
 ;   You must not remove this notice, or any other, from this software.
 
-(ns 
+(ns
   ^{:author "Stuart Sierra, Chas Emerick, Stuart Halloway",
      :doc "This file defines polymorphic I/O utility functions for Clojure."}
     clojure.java.io
     (:require clojure.string)
-    (:import 
+    (:import
      (java.io Reader InputStream InputStreamReader PushbackReader
               BufferedReader File OutputStream
               OutputStreamWriter BufferedWriter Writer
@@ -45,11 +45,11 @@
   nil
   (as-file [_] nil)
   (as-url [_] nil)
-  
+
   String
   (as-file [s] (File. s))
-  (as-url [s] (URL. s))  
-  
+  (as-url [s] (URL. s))
+
   File
   (as-file [f] f)
   (as-url [f] (.toURL (.toURI f)))
@@ -72,7 +72,7 @@
    be unequivocally converted to the requested kind of stream.
 
    Common options include
-   
+
      :append    true to open stream in append mode
      :encoding  string name of encoding to use, e.g. \"UTF-8\".
 
@@ -387,9 +387,9 @@
 
     :buffer-size  buffer size to use, default is 1024.
     :encoding     encoding to use if converting between
-                  byte and char streams.   
+                  byte and char streams.
 
-  Does not close any streams except those it opens itself 
+  Does not close any streams except those it opens itself
   (on a File)."
   {:added "1.2"}
   [input output & opts]
@@ -410,9 +410,9 @@
    versions treat the first argument as parent and subsequent args as
    children relative to the parent."
   {:added "1.2"}
-  ([arg]                      
+  ([arg]
      (as-file arg))
-  ([parent child]             
+  ([parent child]
      (File. ^File (as-file parent) ^String (as-relative-path child)))
   ([parent child & more]
      (reduce file (file parent child) more)))

--- a/src/clj/clojure/java/javadoc.clj
+++ b/src/clj/clojure/java/javadoc.clj
@@ -74,8 +74,8 @@
   Tries *local-javadocs* first, then *remote-javadocs*."
   {:added "1.2"}
   [class-or-object]
-  (let [^Class c (if (instance? Class class-or-object) 
-                    class-or-object 
+  (let [^Class c (if (instance? Class class-or-object)
+                    class-or-object
                     (class class-or-object))]
     (if-let [url (javadoc-url (.getName c))]
       (browse-url url)

--- a/src/clj/clojure/java/shell.clj
+++ b/src/clj/clojure/java/shell.clj
@@ -6,7 +6,7 @@
 ;   the terms of this license.
 ;   You must not remove this notice, or any other, from this software.
 
-(ns 
+(ns
   ^{:author "Chris Houser, Stuart Halloway",
     :doc "Conveniently launch a sub-process providing its stdin and
 collecting its stdout"}
@@ -31,7 +31,7 @@ collecting its stdout"}
   [env & forms]
   `(binding [*sh-env* ~env]
      ~@forms))
-     
+
 (defn- aconcat
   "Concatenates arrays of given type."
   [type & xs]
@@ -49,7 +49,7 @@ collecting its stdout"}
         [cmd opts] (split-with string? args)]
     [cmd (merge default-opts (apply hash-map opts))]))
 
-(defn- ^"[Ljava.lang.String;" as-env-strings 
+(defn- ^"[Ljava.lang.String;" as-env-strings
   "Helper so that callers can pass a Clojure map for the :env to sh."
   [arg]
   (cond
@@ -110,7 +110,7 @@ collecting its stdout"}
   {:added "1.2"}
   [& args]
   (let [[cmd opts] (parse-args args)
-        proc (.exec (Runtime/getRuntime) 
+        proc (.exec (Runtime/getRuntime)
                ^"[Ljava.lang.String;" (into-array cmd)
                (as-env-strings (:env opts))
                (as-file (:dir opts)))


### PR DESCRIPTION
I was looking up a function in the `io` namespace and my Emacs was lighting up red because of the committed white-space.