### PR TITLE
Fixed ambiguity in `and` doc string

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -822,7 +822,7 @@
 
 (defmacro and
   "Evaluates exprs one at a time, from left to right. If a form
-  returns logical false (nil or false), and returns that value and
+  returns logical false (nil or false), (and) returns that value and
   doesn't evaluate any of the other expressions, otherwise it returns
   the value of the last expr. (and) returns true."
   {:added "1.0"}


### PR DESCRIPTION
`and` should refer to the macro, it makes no sense as a (grammatical) conjunction in the sentence.