### PR TITLE
fixing issue with browse-url

### DIFF
--- a/src/clj/clojure/java/browse.clj
+++ b/src/clj/clojure/java/browse.clj
@@ -39,6 +39,11 @@
 
 (def ^:dynamic *open-url-script* (atom :uninitialized))
 
+(defn- success?
+  "Check that a shell command executed successfully"
+  [result]
+  (= 0 (:exit result)))
+
 (defn- open-url-by-script
   "Open url through script"
   [url]
@@ -46,7 +51,7 @@
         script (if (= :uninitialized script)
                  (reset! *open-url-script* (open-url-script-val))
                  script)]
-    (when script (= 0 (:exit (sh/sh script (str url)))))))
+    (when script (success? (sh/sh script (str url))))))
 
 (defn- open-url-in-browser
   "Opens url (a string) in the default system web browser.  May not

--- a/src/clj/clojure/java/browse.clj
+++ b/src/clj/clojure/java/browse.clj
@@ -39,6 +39,15 @@
 
 (def ^:dynamic *open-url-script* (atom :uninitialized))
 
+(defn- open-url-by-script
+  "Open url through script"
+  [url]
+  (let [script @*open-url-script*
+        script (if (= :uninitialized script)
+                 (reset! *open-url-script* (open-url-script-val))
+                 script)]
+    (when script (= 0 (:exit (sh/sh script (str url)))))))
+
 (defn- open-url-in-browser
   "Opens url (a string) in the default system web browser.  May not
   work on all platforms.  Returns url on success, nil if not
@@ -67,10 +76,7 @@
   "Open url in a browser"
   {:added "1.2"}
   [url]
-  (let [script @*open-url-script*
-        script (if (= :uninitialized script)
-                 (reset! *open-url-script* (open-url-script-val))
-                 script)]
-    (or (when script (= 0 (:exit (sh/sh script (str url)))))
-        (open-url-in-browser url)
-        (open-url-in-swing url))))
+  (or (open-url-by-script url)
+      (open-url-in-browser url)
+      (open-url-in-swing url))
+  )

--- a/src/clj/clojure/java/browse.clj
+++ b/src/clj/clojure/java/browse.clj
@@ -71,6 +71,6 @@
         script (if (= :uninitialized script)
                  (reset! *open-url-script* (open-url-script-val))
                  script)]
-    (or (when script (sh/sh script (str url)) true)
+    (or (when script (= 0 (:exit (sh/sh script (str url)))))
         (open-url-in-browser url)
         (open-url-in-swing url))))


### PR DESCRIPTION
When xdg-utils are installed on my platform, and the xdg-open command fails, (clojure.java.browse/browse-url) ignores this error and silently fails.  This fix will allow the (or ..) logic to continue evaluating to try the next method.
