### PR TITLE
Sane line-breaks for deref docs

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2296,16 +2296,19 @@
             timeout-val))))
      
 (defn deref
-  "Also reader macro: @ref/@agent/@var/@atom/@delay/@future/@promise. Within a transaction,
-  returns the in-transaction-value of ref, else returns the
-  most-recently-committed value of ref. When applied to a var, agent
-  or atom, returns its current state. When applied to a delay, forces
-  it if not already forced. When applied to a future, will block if
-  computation not complete. When applied to a promise, will block
-  until a value is delivered.  The variant taking a timeout can be
-  used for blocking references (futures and promises), and will return
-  timeout-val if the timeout (in milliseconds) is reached before a
-  value is available. See also - realized?."
+  "Also reader macro: @ref/@agent/@var/@atom/@delay/@future/@promise.
+  Within a transaction, returns the in-transaction-value of ref,
+  else returns the most-recently-committed value of ref.
+  
+  When applied to a var, agent or atom, returns its current state.
+  When applied to a delay, forces it if not already forced.
+  When applied to a future, will block if computation not complete.
+  When applied to a promise, will block until a value is delivered.
+	
+  The variant taking a timeout can be used for blocking references
+  (futures and promises), and will return timeout-val if the timeout
+  (in milliseconds) is reached before a value is available.
+  See also - realized?."
   {:added "1.0"
    :static true}
   ([ref] (if (instance? clojure.lang.IDeref ref)


### PR DESCRIPTION
The dangling "Within a transaction, " was killing me.. so I reformatted these lines to fit nicely in my editor :)