### PR TITLE
Simplify take-last

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2936,7 +2936,7 @@
   {:added "1.1"
    :static true}
   [n coll]
-  (drop (count (drop n coll)) coll)
+  (drop (- (count coll) n) coll)
 
 (defn drop-while
   "Returns a lazy sequence of the items in coll starting from the

--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2936,10 +2936,7 @@
   {:added "1.1"
    :static true}
   [n coll]
-  (loop [s (seq coll), lead (seq (drop n coll))]
-    (if lead
-      (recur (next s) (next lead))
-      s)))
+  (drop (count (drop n coll)) coll)
 
 (defn drop-while
   "Returns a lazy sequence of the items in coll starting from the


### PR DESCRIPTION
Why take-last used more complex implement? Just for better performence?