### PR TITLE
use invokedynamic instead of the reflection API when possible

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,7 @@
   <property name="clojure_noversion_jar" location="clojure.jar"/>
 
   <property name="directlinking" value="true"/>
+  <property name="emitindy" value="true"/>
 
   <target name="init" depends="clean">
     <tstamp/>
@@ -55,6 +56,7 @@
          <!--<sysproperty key="clojure.compiler.disable-locals-clearing" value="true"/>-->
        <!--<sysproperty key="clojure.compile.warn-on-reflection" value="true"/>-->
         <sysproperty key="clojure.compiler.direct-linking" value="true"/>
+      <sysproperty key="clojure.compiler.emit-indy" value="true"/>
       <sysproperty key="java.awt.headless" value="true"/>
       <arg value="clojure.core"/>
       <arg value="clojure.core.protocols"/>
@@ -92,6 +94,7 @@
     <javac srcdir="${jtestsrc}" destdir="${test-classes}" includeJavaRuntime="yes"
            debug="true" source="1.8" target="1.8" includeantruntime="no"/>
     <echo>Direct linking = ${directlinking}</echo>
+  	<echo>Emit invokedynamic = ${emitindy}</echo>
     <java classname="clojure.lang.Compile"
           classpath="${test-classes}:${test}:${build}:${cljsrc}:${maven.test.classpath}"
           failonerror="true"
@@ -100,6 +103,7 @@
         <!--<sysproperty key="clojure.compiler.elide-meta" value="[:doc]"/>-->
         <!--<sysproperty key="clojure.compiler.disable-locals-clearing" value="true"/>-->
       <sysproperty key="clojure.compiler.direct-linking" value="${directlinking}"/>
+      <sysproperty key="clojure.compiler.emit-indy" value="${emitindy}"/>
       <arg value="clojure.test-clojure.protocols.examples"/>
       <arg value="clojure.test-clojure.genclass.examples"/>
       <arg value="clojure.test-clojure.compilation.load-ns"/>
@@ -115,6 +119,7 @@
       <sysproperty key="clojure.test-clojure.exclude-namespaces"
                    value="#{clojure.test-clojure.compilation.load-ns}"/>
       <sysproperty key="clojure.compiler.direct-linking" value="${directlinking}"/>
+      <sysproperty key="clojure.compiler.emit-indy" value="${emitindy}"/>
       <classpath>
         <pathelement path="${maven.test.classpath}"/>
         <path location="${test-classes}"/>
@@ -132,6 +137,7 @@
           unless="maven.test.skip">
     <java classname="clojure.main" failonerror="true" fork="true">
       <sysproperty key="clojure.compiler.direct-linking" value="${directlinking}"/>
+      <sysproperty key="clojure.compiler.emit-indy" value="${emitindy}"/>
       <classpath>
         <pathelement path="${maven.test.classpath}"/>
         <path location="${test-classes}"/>

--- a/src/jvm/clojure/lang/RT.java
+++ b/src/jvm/clojure/lang/RT.java
@@ -20,6 +20,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.io.*;
 import java.lang.reflect.Array;
+import java.lang.invoke.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.security.AccessController;
@@ -2392,5 +2393,24 @@ static public Object[] aclone(Object[] xs){
 	return xs.clone();
 }
 
+public static CallSite bsm_invoke_static(MethodHandles.Lookup lookup, String methodName, MethodType type, String className){
+	return RTMetaFactories.bsm_invoke_static(lookup, methodName, type, className);
+}
+
+public static CallSite bsm_invoke_constructor(MethodHandles.Lookup lookup, String methodName, MethodType type, String className){
+	return RTMetaFactories.bsm_invoke_constructor(lookup, methodName, type, className);
+}
+
+public static CallSite bsm_invoke_instance(MethodHandles.Lookup lookup, String methodName, MethodType type){
+	return RTMetaFactories.bsm_invoke_instance(lookup, methodName, type);
+}
+
+public static CallSite bsm_invoke_no_arg_member(MethodHandles.Lookup lookup, String memberName, MethodType type, Integer boxedRequireField){
+	return RTMetaFactories.bsm_invoke_no_arg_member(lookup, memberName, type, boxedRequireField);
+}
+
+public static CallSite bsm_set_instance_field(MethodHandles.Lookup lookup, String fieldName, MethodType type){
+	return RTMetaFactories.bsm_set_instance_field(lookup, fieldName, type);
+}
 
 }

--- a/src/jvm/clojure/lang/RTMetaFactories.java
+++ b/src/jvm/clojure/lang/RTMetaFactories.java
@@ -1,0 +1,426 @@
+/**
+ *   Copyright (c) Rich Hickey. All rights reserved.
+ *   The use and distribution terms for this software are covered by the
+ *   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ *   which can be found in the file epl-v10.html at the root of this distribution.
+ *   By using this software in any fashion, you are agreeing to be bound by
+ * 	 the terms of this license.
+ *   You must not remove this notice, or any other, from this software.
+ **/
+
+package clojure.lang;
+
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.exactInvoker;
+import static java.lang.invoke.MethodHandles.filterArguments;
+import static java.lang.invoke.MethodHandles.filterReturnValue;
+import static java.lang.invoke.MethodHandles.foldArguments;
+import static java.lang.invoke.MethodHandles.identity;
+import static java.lang.invoke.MethodHandles.insertArguments;
+import static java.lang.invoke.MethodType.methodType;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+class RTMetaFactories{
+	private static final Class<? extends Annotation> CALLER_SENSITIVE;
+	private static final MethodHandle REFLECTOR_INVOKE_STATIC_METHOD;
+	private static final MethodHandle REFLECTOR_INVOKE_CONSTRUCTOR;
+	private static final MethodHandle REFLECTOR_INVOKE_INSTANCE_METHOD;
+	private static final MethodHandle REFLECTOR_INVOKE_NO_ARG_INSTANCE_MEMBER;
+	private static final MethodHandle REFLECTOR_SET_INSTANCE_FIELD;
+	private static final MethodHandle BOX_ARG;
+	private static final MethodHandle PREP_RET;
+	static
+		{
+		CALLER_SENSITIVE = findCallerSensitiveClass();
+
+		Lookup lookup = MethodHandles.lookup();
+		try
+			{
+			REFLECTOR_INVOKE_STATIC_METHOD = lookup.findStatic(Reflector.class, "invokeStaticMethod",
+					methodType(Object.class, Class.class, String.class, Object[].class));
+			REFLECTOR_INVOKE_CONSTRUCTOR = lookup.findStatic(Reflector.class, "invokeConstructor",
+					methodType(Object.class, Class.class, Object[].class));
+			REFLECTOR_INVOKE_INSTANCE_METHOD = lookup.findStatic(Reflector.class, "invokeInstanceMethod",
+					methodType(Object.class, Object.class, String.class, Object[].class));
+			REFLECTOR_INVOKE_NO_ARG_INSTANCE_MEMBER = lookup.findStatic(Reflector.class, "invokeNoArgInstanceMember",
+					methodType(Object.class, Object.class, String.class, boolean.class));
+			REFLECTOR_SET_INSTANCE_FIELD = lookup.findStatic(Reflector.class, "setInstanceField",
+					methodType(Object.class, Object.class, String.class, Object.class));
+
+			BOX_ARG =  lookup.findStatic(Reflector.class, "boxArg",
+					methodType(Object.class, Class.class, Object.class));
+			PREP_RET = lookup.findStatic(Reflector.class, "prepRet",
+					methodType(Object.class, Class.class, Object.class))
+					.bindTo(Boolean.class).asType(methodType(Boolean.class, Object.class));
+		  }
+		catch (NoSuchMethodException | IllegalAccessException e)
+	  	{
+			throw new AssertionError(e);
+	  	}
+		}
+
+	@SuppressWarnings("unchecked")
+	private static Class<? extends Annotation> findCallerSensitiveClass() {
+		Class<?> callerSensitive;
+		try
+			{  // CallerSensitive for JDK8
+			callerSensitive = Class.forName("sun.reflect.CallerSensitive", false, null);
+			}
+		catch (ClassNotFoundException e)
+			{
+			try
+				{  // CallerSensitive for JDK9+
+				callerSensitive = Class.forName("jdk.internal.reflect.CallerSensitive", false, null);
+				}
+			catch (ClassNotFoundException e2)
+				{
+				throw new AssertionError(e2);
+				}
+		}
+		return (Class<? extends Annotation>) callerSensitive;
+	}
+
+	private static final ClassValue<MethodHandle> BOX_ARG_CACHE = new ClassValue<MethodHandle>() {
+		protected MethodHandle computeValue(Class<?> type) {
+			if (!type.isPrimitive())
+				throw new AssertionError("only primitive conversion are allowed");
+			return BOX_ARG.bindTo(type).asType(methodType(type, Object.class));
+		}
+	};
+
+	private static MethodHandle boxArg(Class<?> c) {
+		if (!c.isPrimitive())
+			return null;
+		return BOX_ARG_CACHE.get(c);
+	}
+
+	private static MethodHandle prepRet(Class<?> c) {
+		if (c != Boolean.class)
+			return null;
+		return PREP_RET;
+	}
+
+	private static MethodHandle convert(MethodHandle mh, int start) {
+		// filter arguments
+		MethodType type = mh.type();
+		int parameterCount = type.parameterCount();
+		MethodHandle[] filters = null; // lazily allocated
+		for(int i = start; i < parameterCount; i++)
+			{
+			MethodHandle boxArg = boxArg(type.parameterType(i));
+			if (boxArg != null)
+				{
+				if (filters == null)  
+					filters = new MethodHandle[parameterCount];
+				filters[i] = boxArg;
+				}
+			}
+		if (filters != null)
+			mh = filterArguments(mh, 0, filters);
+
+		// filter return value
+		MethodHandle prepRet = prepRet(type.returnType());
+		if (prepRet != null)
+			mh = filterReturnValue(mh, prepRet);
+		return mh;
+	}
+
+	static MethodHandle adjustTo(MethodHandle mh, int start, MethodType type) {
+		MethodHandle converted = convert(mh, start);
+		if (mh.isVarargsCollector())   // re-enable varargs collecting
+			converted = converted.asVarargsCollector(Object[].class);
+		return converted.asType(type);
+	}
+
+
+	/* behaviors */  
+
+	private static MethodHandle asStaticMethodMH(Lookup lookup, Class<?> staticClass, String methodName, int arity) {
+		if (methodName.equals("new"))
+			return asConstructorMH(lookup, staticClass, arity);
+
+		List<Method> methods = Reflector.getMethods(staticClass, arity, methodName, true);
+		if (methods.size() != 1)
+			return null;
+
+		Method method = methods.get(0);
+		if (method.isAnnotationPresent(CALLER_SENSITIVE))
+			return null;
+
+		MethodHandle mh;
+		try
+			{
+			mh = lookup.unreflect(method);
+			}
+		catch (IllegalAccessException e)
+			{  // don't try to optimize, so the stack trace of the error is identical as the one without indy
+			return null;
+			}
+		return mh;
+	}
+
+	private static MethodHandle asConstructorMH(Lookup lookup, Class<?> staticClass, int arity) { 
+		List<Constructor<?>> constructors = Reflector.getConstructors(staticClass, arity);
+		if (constructors.size() != 1)
+			return null;
+
+		Constructor<?> constructor = constructors.get(0);
+		if (constructor.isAnnotationPresent(CALLER_SENSITIVE))
+			return null;
+
+		MethodHandle mh;
+		try
+			{
+			mh = lookup.unreflectConstructor(constructor);
+			}
+		catch (IllegalAccessException e)
+			{  // don't try to optimize, so the stack trace of the error is identical as the one without indy
+			return null;
+			}
+		return mh;
+	}
+
+	private static MethodHandle asInstanceMethodMH(Lookup lookup, Class<?> dynamicClass, String methodName, int arity) {
+		List<Method> methods = Reflector.getMethods(dynamicClass, arity, methodName, false);
+		if (methods.size() != 1)
+			return null;
+
+		Method method = methods.get(0);
+		if (method.isAnnotationPresent(CALLER_SENSITIVE))
+			return null;
+
+		try
+			{
+			return lookup.unreflect(method);
+			}
+		catch (IllegalAccessException e)
+			{  // don't try to optimize, so the stack trace of the error is identical as the one without indy
+			return null;
+			}
+	}
+
+	private static MethodHandle asGetterFieldMH(Lookup lookup, Class<?> dynamicClass, String fieldName) {
+		Field field = Reflector.getField(dynamicClass, fieldName, false);
+		if (field == null)
+			return null;
+
+		try
+			{
+			return lookup.unreflectGetter(field);
+			}
+		catch (IllegalAccessException e)
+			{  // don't try to optimize, so the stack trace of the error is identical as the one without indy
+			return null;
+			}
+	}
+
+	private static MethodHandle asSetterFieldMH(Lookup lookup, Class<?> dynamicClass, String fieldName) {
+		Field field = Reflector.getField(dynamicClass, fieldName, false);
+		if (field == null)
+			return null;
+
+		MethodHandle setter;
+		try
+			{
+			setter = lookup.unreflectSetter(field);
+			}
+		catch (IllegalAccessException e)
+			{  // don't try to optimize, so the stack trace of the error is identical as the one without indy
+			return null;
+			}
+
+		return foldArguments(dropArguments(identity(Object.class), 0, Object.class), setter);
+	}
+
+
+	/* fallback method handles that calls the Reflector APIs */
+
+	static MethodHandle dynamicInvokeStaticMethod(Class<?> staticClass, String methodName, int arity){
+		return insertArguments(REFLECTOR_INVOKE_STATIC_METHOD, 0, staticClass, methodName)
+				.asCollector(Object[].class, arity);
+	}
+
+	static MethodHandle dynamicInvokeConstructor(Class<?> staticClass, int arity){
+		return insertArguments(REFLECTOR_INVOKE_CONSTRUCTOR, 0, staticClass)
+				.asCollector(Object[].class, arity);
+	}
+
+	static MethodHandle dynamicInvokeInstanceMethod(String methodName, int arity){
+		return insertArguments(REFLECTOR_INVOKE_INSTANCE_METHOD, 1, methodName)
+				.asCollector(Object[].class, arity);
+	}
+
+	static MethodHandle dynamicInvokeNoArgInstanceMember(String memberName, boolean requireField) {
+		return insertArguments(REFLECTOR_INVOKE_NO_ARG_INSTANCE_MEMBER, 1, memberName, requireField);
+	}
+
+	static MethodHandle dynamicSetInstanceField(String fieldName) {
+		return insertArguments(REFLECTOR_SET_INSTANCE_FIELD, 1, fieldName);
+	}
+
+
+	/* a versatile inlining cache used for all receiver based dispatch */
+
+	private static final class InlineCache extends MutableCallSite {
+		private interface Resolver {
+			MethodHandle resolve(Class<?> dynamicClass, MethodType type);
+			MethodHandle fallback(MethodType type);
+		}
+
+		private static final int MAX_DEPTH = 5;
+		private static final int MAX_BAILOUT = 1;
+
+		private static final MethodHandle TYPE_CHECK;
+		private static final MethodHandle FALLBACK;
+		static
+			{
+			Lookup lookup = MethodHandles.lookup();
+			try
+				{
+				TYPE_CHECK = lookup.findStatic(InlineCache.class, "typeCheck",
+						methodType(boolean.class, Class.class, Object.class));
+				FALLBACK = lookup.findVirtual(InlineCache.class, "fallback",
+						methodType(MethodHandle.class, Object.class));
+				}
+			catch (NoSuchMethodException | IllegalAccessException e)
+				{
+				throw new AssertionError(e);
+				}
+		}
+
+		private static boolean typeCheck(Class<?> c, Object target) {
+			return c == target.getClass();   // implicit NPE
+		}
+
+		private final Resolver resolver;
+		private final InlineCache root;
+		private final int depth;
+		private final int bailout;
+
+		InlineCache(MethodType type, Resolver resolver){
+			super(type);
+			this.resolver = resolver;
+			this.root = this;
+			this.depth = 1;
+			this.bailout = 0;
+			setTarget(foldArguments(exactInvoker(type), FALLBACK.bindTo(this)));
+		}
+
+		private InlineCache(MethodType type, Resolver resolver, InlineCache root, int depth, int bailout){
+			super(type);
+			this.resolver = resolver;
+			this.root = root;
+			this.depth = depth;
+			this.bailout = bailout;
+			setTarget(foldArguments(exactInvoker(type), FALLBACK.bindTo(this)));
+		}
+
+		private MethodHandle fallback(Object target) {
+			MethodType type = type();
+			if (depth == MAX_DEPTH)  // the inlining cache starts to become too big,
+				{                      // we still keep the previous stages to optimize the common cases
+				MethodHandle mh = resolver.fallback(type).asType(type);
+				setTarget(mh);
+				return mh;
+				}
+
+			Class<?> dynamicClass = target.getClass();
+			int bailout = this.bailout;
+			MethodHandle mh = resolver.resolve(dynamicClass, type);
+			if (mh == null)
+				{  // bailout
+				mh = resolver.fallback(type()).asType(type);
+				if (bailout == MAX_BAILOUT)
+					{  // too many bailouts, discard the inlining cache and revert to dynamically invoke for all instances
+					root.setTarget(mh);
+					return mh;
+					}
+
+				bailout++;
+				}
+			else
+				{
+				mh = adjustTo(mh, 1, type());
+				}
+
+			MethodHandle gwt = MethodHandles.guardWithTest(
+					TYPE_CHECK.bindTo(dynamicClass),
+					mh,
+					new InlineCache(type, resolver, root, depth + 1, bailout).dynamicInvoker());
+			setTarget(gwt);
+			return mh; 
+		}
+	}
+
+
+	/* boostrap entrypoints */
+
+	static CallSite bsm_invoke_static(Lookup lookup, String methodName, MethodType type, String className){
+		Class<?> staticClass = RT.classForName(className);
+		int arity = type.parameterCount();
+		MethodHandle mh = asStaticMethodMH(lookup, staticClass, methodName, arity);
+		if (mh == null)
+			mh = dynamicInvokeStaticMethod(staticClass, methodName, arity).asType(type);
+		return new ConstantCallSite(adjustTo(mh, 0, type));
+	}
+
+	static CallSite bsm_invoke_constructor(Lookup lookup, String methodName, MethodType type, String className){
+		Class<?> staticClass = RT.classForName(className);
+		int arity = type.parameterCount();
+		MethodHandle mh = asConstructorMH(lookup, staticClass, arity);
+		if (mh == null)
+			mh = dynamicInvokeConstructor(staticClass, arity).asType(type);
+		return new ConstantCallSite(adjustTo(mh, 0, type));
+	}
+
+	static CallSite bsm_invoke_instance(Lookup lookup, String methodName, MethodType type){
+		return new InlineCache(type, new InlineCache.Resolver() {
+			public MethodHandle resolve(Class<?> dynamicClass, MethodType type) {
+				return asInstanceMethodMH(lookup, dynamicClass, methodName, type.parameterCount() - 1);
+			}
+			public MethodHandle fallback(MethodType type) {
+				return dynamicInvokeInstanceMethod(methodName, type.parameterCount() - 1);
+			}
+		});
+	}
+
+	static CallSite bsm_invoke_no_arg_member(Lookup lookup, String memberName, MethodType type, Integer boxedRequireField){
+		boolean requireField = boxedRequireField != 0;
+		return new InlineCache(type, new InlineCache.Resolver() {
+			public MethodHandle resolve(Class<?> dynamicClass, MethodType type) {
+				if (requireField)
+					return asGetterFieldMH(lookup, dynamicClass, memberName);
+				List meths = Reflector.getMethods(dynamicClass, 0, memberName, false);
+				if(!meths.isEmpty())
+					return asInstanceMethodMH(lookup, dynamicClass, memberName, 0);
+				return asGetterFieldMH(lookup, dynamicClass, memberName);
+			}
+			public MethodHandle fallback(MethodType type) {
+				return dynamicInvokeNoArgInstanceMember(memberName, requireField);
+			}
+		});
+	}
+
+	static CallSite bsm_set_instance_field(Lookup lookup, String fieldName, MethodType type){
+		return new InlineCache(type, new InlineCache.Resolver() {
+			public MethodHandle resolve(Class<?> dynamicClass, MethodType type) {
+				return asSetterFieldMH(lookup, dynamicClass, fieldName);
+			}
+			public MethodHandle fallback(MethodType type) {
+				return dynamicSetInstanceField(fieldName);
+			}
+		});
+	}
+}

--- a/src/jvm/clojure/lang/Reflector.java
+++ b/src/jvm/clojure/lang/Reflector.java
@@ -78,7 +78,7 @@ private static Method tryFindMethod(Class c, Method m) {
 	}
 }
 
-static Method toAccessibleSuperMethod(Method m, Object target) {
+private static Method toAccessibleSuperMethod(Method m, Object target) {
 	Method selected = m;
 	while(selected != null) {
 		if(canAccess(selected, target)) return selected;

--- a/src/jvm/clojure/lang/Reflector.java
+++ b/src/jvm/clojure/lang/Reflector.java
@@ -78,7 +78,7 @@ private static Method tryFindMethod(Class c, Method m) {
 	}
 }
 
-private static Method toAccessibleSuperMethod(Method m, Object target) {
+static Method toAccessibleSuperMethod(Method m, Object target) {
 	Method selected = m;
 	while(selected != null) {
 		if(canAccess(selected, target)) return selected;
@@ -272,17 +272,22 @@ public static boolean isAccessibleMatch(Method lhs, Method rhs, Object target) {
 	return match;
 }
 
+static List<Constructor<?>> getConstructors(Class<?> c, int arity) {
+	Constructor<?>[] allctors = c.getConstructors();
+	ArrayList<Constructor<?>> ctors = new ArrayList<>();
+	for(int i = 0; i < allctors.length; i++)
+		{
+		Constructor<?> ctor = allctors[i];
+		if(ctor.getParameterCount() == arity)
+			ctors.add(ctor);
+		}
+	return ctors;
+}
+
 public static Object invokeConstructor(Class c, Object[] args) {
 	try
 		{
-		Constructor[] allctors = c.getConstructors();
-		ArrayList ctors = new ArrayList();
-		for(int i = 0; i < allctors.length; i++)
-			{
-			Constructor ctor = allctors[i];
-			if(ctor.getParameterTypes().length == args.length)
-				ctors.add(ctor);
-			}
+		List ctors = getConstructors(c, args.length);
 		if(ctors.isEmpty())
 			{
 			throw new IllegalArgumentException("No matching ctor found"


### PR DESCRIPTION
The compiler is patched to use invokedynamic instead of the reflection API when it doesn't know the function to call statically.

Invoking a static method or a constructor is done just by delaying the resolution at runtime.
For the other invocations, an inlining cache is installed to trap the receiver class and do the resolution each time there is a new receiver class.

For all invocations, if a resolution find several overloads, invokedynamic is wire up to call the reflection API, said differently, in case of multi-dispatch, this patch fallback to use the reflection.
Also If no method is found during the resolution, the Reflector API is called so the error messages (and the call stack) are exactly the same.

I've not touch to the error warning in case of reflection because the decision to make an invocation inlinable or not is done at runtime.
