### PR TITLE
Fix typo in docstring for `chars` and friends

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -5382,17 +5382,17 @@
   [xs] `(. clojure.lang.Numbers booleans ~xs))
 
 (definline bytes
-  "Casts to bytes[]"
+  "Casts to byte[]"
   {:added "1.1"}
   [xs] `(. clojure.lang.Numbers bytes ~xs))
 
 (definline chars
-  "Casts to chars[]"
+  "Casts to char[]"
   {:added "1.1"}
   [xs] `(. clojure.lang.Numbers chars ~xs))
 
 (definline shorts
-  "Casts to shorts[]"
+  "Casts to short[]"
   {:added "1.1"}
   [xs] `(. clojure.lang.Numbers shorts ~xs))
 


### PR DESCRIPTION
It should be `char[]`, not `chars[]`.

Hi! This project does not accept pull requests.

- [x] Please see the guidelines for contribution on how to file issues or provide patches:

https://github.com/clojure/clojure/blob/master/CONTRIBUTING.md
