### PR TITLE
clojure.core/take-last: call with `coll` only, like drop-last

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -2966,11 +2966,12 @@
   of coll may be no better than linear time.  For vectors, see also subvec."
   {:added "1.1"
    :static true}
-  [n coll]
-  (loop [s (seq coll), lead (seq (drop n coll))]
-    (if lead
-      (recur (next s) (next lead))
-      s)))
+  ([coll] (take-last 1 coll))
+  ([n coll]
+   (loop [s (seq coll), lead (seq (drop n coll))]
+     (if lead
+       (recur (next s) (next lead))
+       s))))
 
 (defn drop-while
   "Returns a lazy sequence of the items in coll starting from the


### PR DESCRIPTION
Hi! This project does not accept pull requests.

Please see the guidelines for contribution on how to file issues or provide patches:

https://github.com/clojure/clojure/blob/master/CONTRIBUTING.md
